### PR TITLE
Added creation of mod only dll, updated readme & small path adjustments

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,24 @@ supported (Steam might work, GOG will not, due to the game files being built in 
 
 ## How to install
 
+### Option A: bundled (easiest)
+
 - Download the zip for your version from the "Releases" page.
   - For GOG or Steam, download "FuriousTareIL2CPP.zip"
 - Unzip the files into your game directory
   - E.g. `Steam\steamapps\common\Disco Elysium`
+
+This zip bundles the BepInEx mod loader (v6.0.0-be.688, IL2CPP, Windows x64), pre-configured.
+If you already installed BepInEx or other mods, prefer Option B so your existing setup isn't overwritten.
+
+### Option B: plugin only (bring your own BepInEx)
+
+- Install BepInEx 6 (IL2CPP, Windows x64) into your game directory, following the [BepInEx installation guide](https://docs.bepinex.dev/master/articles/user_guide/installation/index.html).
+  - The mod is developed and tested against [v6.0.0-be.688](https://builds.bepinex.dev/projects/bepinex_be/688/BepInEx-Unity.IL2CPP-win-x64-6.0.0-be.688%2B4901521.zip).
+
+- Run the game once, so BepInEx generates its interop assemblies.
+- Download "FuriousTareIL2CPP_PluginOnly.zip" from the "Releases" page.
+- Unzip it into your game directory. The plugin DLL should end up at `Disco Elysium\BepInEx\plugins\FuriousTare\FuriousTareIL2CPP.dll`.
 
 ## Configuration
 

--- a/copy_to_steam.ps1
+++ b/copy_to_steam.ps1
@@ -1,6 +1,6 @@
 ﻿Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 
-Copy-Item -Path "FuriousTareIL2CPP\bin\Release\net6.0\FuriousTareIL2CPP.dll" -Destination "F:\Games\Steam\steamapps\common\Disco Elysium\BepInEx\plugins\FuriousTare\"
+Copy-Item -Path "FuriousTareIL2CPP\bin\Release\net6.0\FuriousTareIL2CPP.dll" -Destination "C:\Program Files (x86)\Steam\steamapps\common\Disco Elysium\BepInEx\plugins\FuriousTare\"
 
 echo "Copied!"

--- a/package.ps1
+++ b/package.ps1
@@ -13,6 +13,11 @@ Copy-Item -Path "FuriousTareIL2CPP\bin\Release\net6.0\FuriousTareIL2CPP.dll" -De
 
 $Today = (Get-Date).ToUniversalTime().ToString('yyyy-MM-dd')
 Compress-Archive -Path "temp\package\IL2CPP\*" -DestinationPath "temp\FuriousTareIL2CPP_$Today.zip"
+
+mkdir -Path "temp\package\PluginOnly\BepInEx\plugins\FuriousTare"
+Copy-Item -Path "FuriousTareIL2CPP\bin\Release\net6.0\FuriousTareIL2CPP.dll" -Destination "temp\package\PluginOnly\BepInEx\plugins\FuriousTare"
+Compress-Archive -Path "temp\package\PluginOnly\*" -DestinationPath "temp\FuriousTareIL2CPP_PluginOnly_$Today.zip"
+
 Remove-Item -Force -Recurse -ErrorAction "Continue" -Path "temp/package"
 
 echo "Done!"


### PR DESCRIPTION
Hey, just a small PR, addressing issue #7 by adding an additional install option (plugin only) to the `README.md` and added plugin only zip creation to the `package.ps1` script. 

Adjusted `copy_to_steam.ps1` to the most commonly used steam installation path. (You can exclude this, if you want).

The `README.md` states the used `BepInEx` version and links to the installation guide and download link.

The new lines inside `package.ps1` create the right folder structure, copies the build mod dll into it and zips it.

I did not test both install options with newer versions of `BepInEx`.

Closes #7 