### PR TITLE
Removes ad for zero parades on the main menu.

### DIFF
--- a/FuriousTareIL2CPP/Patches/RemoveMainMenuAd.cs
+++ b/FuriousTareIL2CPP/Patches/RemoveMainMenuAd.cs
@@ -1,0 +1,34 @@
+using HarmonyLib;
+
+namespace FuriousTareIL2CPP.Patches;
+
+/**
+ * The main menu shows an ad banner for "Zero Parades" which opens a store page when clicked.
+ *
+ * This hides it by deactivating the ad button's GameObject as soon as it wakes up and prevents anything else from re-enabling it.
+ */
+
+[HarmonyPatch(typeof(MainMenuAdButton))]
+public class RemoveMainMenuAd
+{
+    [HarmonyPostfix]
+    [HarmonyPatch(
+        nameof(MainMenuAdButton.Awake)
+    )]
+    public static void AwakeHook(MainMenuAdButton __instance)
+    {
+        Logger.Log.LogInfo(
+            $"Hiding main menu ad: \"{FuriousTareUtils.GetFullPath(__instance.gameObject)}\""
+        );
+        __instance.gameObject.SetActive(false);
+    }
+
+    [HarmonyPrefix]
+    [HarmonyPatch(
+        nameof(MainMenuAdButton.Enable)
+    )]
+    public static void EnableHook(ref bool __runOriginal)
+    {
+        __runOriginal = false;
+    }
+}

--- a/FuriousTareIL2CPP/PluginEntryPoint.cs
+++ b/FuriousTareIL2CPP/PluginEntryPoint.cs
@@ -17,6 +17,7 @@ public class PluginEntryPoint
         typeof(HandHudReplaceHeldItem),
         typeof(MuzzleKimsBark),
         typeof(RemapVoiceOvers), // should apply after VoiceOverFixAlternatives by using low priority
+        typeof(RemoveMainMenuAd),
         typeof(TweakHudWhiteSpace),
         typeof(SkipIncorrectVoiceOver),
         typeof(StopWavingThatFlashlight),

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Some patches for dialogue fixes are marked with the "Articy ID", representing th
   from the HUD until you un-equip & re-equip it.
 - `MuzzleKimsBark`: When attempting to open the locked apartment door, Kim's "bark" voice-over clip would trigger multiple
   times, making it much louder.
+- `RemoveMainMenuAd`: Removes the ad banner for "Zero Parades" from the main menu.
 - `ScrollSensitivityTweaks`: Some scrolling text, like the Thought Cabinet description panel, has very low scrolling sensitivity.
   - The sensitivity is configurable per panel.
 - `SkipIncorrectVoiceOver`: `0x0100005800001E34`: The wrong voice-over clip plays when Cindy the Skull looks at Joyce.


### PR DESCRIPTION
Hey, also just a small pr for the open issue #5. It deactivates the object after the game calls `Awake()` and prevents later calls to enable it again, by skipping is `Enable()` call.

It does not reverts layout changes being done to the main menu layout, but it looks fine for me.

fixes #5 