### PR TITLE
Redirect lookup for non-existing franconigerian cavalry boots item id to real one

### DIFF
--- a/FuriousTareIL2CPP/Patches/FranconigerianCavalryBoots.cs
+++ b/FuriousTareIL2CPP/Patches/FranconigerianCavalryBoots.cs
@@ -1,0 +1,53 @@
+using HarmonyLib;
+using Sunshine.Dialogue;
+
+namespace FuriousTareIL2CPP.Patches;
+
+/**
+ * The Franconigerian Cavalry Boots are supposed to count towards the Royalist reenactor dress code, but the item ID ("shoes_cavalry") doesn't match the ID the dress code condition checks for ("boots_cavalry").
+ *
+ * No item with ID "boots_cavalry" exists in game, so any check for it always fails. This remaps checks for the wrong ID to the real item ID.
+ */
+
+[HarmonyPatch(typeof(InventoryLuaFunctions))]
+public class FranconigerianCavalryBoots
+{
+    private const string WrongItemId = "boots_cavalry";
+    private const string CorrectItemId = "shoes_cavalry";
+
+    [HarmonyPrefix]
+    [HarmonyPatch(
+        nameof(InventoryLuaFunctions.CheckItem)
+    )]
+    public static void CheckItemHook(ref bool __runOriginal, ref bool __result, string itemName)
+    {
+        if (itemName != WrongItemId)
+        {
+            return;
+        }
+
+        __result = InventoryLuaFunctions.CheckItem(CorrectItemId);
+        __runOriginal = false;
+        Logger.Log.LogInfo(
+            $"Remapped CheckItem(\"{WrongItemId}\") to \"{CorrectItemId}\". Result: {__result}"
+        );
+    }
+
+    [HarmonyPrefix]
+    [HarmonyPatch(
+        nameof(InventoryLuaFunctions.CheckEquipped)
+    )]
+    public static void CheckEquippedHook(ref bool __runOriginal, ref bool __result, string itemName)
+    {
+        if (itemName != WrongItemId)
+        {
+            return;
+        }
+
+        __result = InventoryLuaFunctions.CheckEquipped(CorrectItemId);
+        __runOriginal = false;
+        Logger.Log.LogInfo(
+            $"Remapped CheckEquipped(\"{WrongItemId}\") to \"{CorrectItemId}\". Result: {__result}"
+        );
+    }
+}

--- a/FuriousTareIL2CPP/PluginEntryPoint.cs
+++ b/FuriousTareIL2CPP/PluginEntryPoint.cs
@@ -13,6 +13,7 @@ public class PluginEntryPoint
         typeof(AbilityLabelOverflow),
         typeof(DisableCollageMode),
         typeof(DialoguePathFixes),
+        typeof(FranconigerianCavalryBoots),
         typeof(HandHud),
         typeof(HandHudReplaceHeldItem),
         typeof(MuzzleKimsBark),

--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ Some patches for dialogue fixes are marked with the "Articy ID", representing th
   the correct response, _and also_ the response for the other dialogue choice ("I like high fidelity *anything*").
 - `DisableCollageMode`: Collage mode adds 2 to 6 seconds loading time at game startup. We can disable it for a speed boost.
   (Just disable this specific patch if you want to use Collage mode.)
+- `FranconigerianCavalryBoots`: The Franconigerian Cavalry Boots are supposed to count towards the Royalist reenactor
+  dress code, but the dress code condition checks for an item ID that doesn't exist (`boots_cavalry` instead of the
+  boots' real ID, `shoes_cavalry`). Checks for non-existent ID are remapped to the real one.
 - `HandHud`: The hand HUD icons wouldn't respond to mouseover or clicks, except for a small area below the icons.
   - This was because the clock's "rectangle" actually overlapped and blocked the icons.
 - `HandHudReplaceHeldItem`: When swapping a held consumable item (booze, smokes) with another, the new item would not be usable


### PR DESCRIPTION
Hey I also saw your #1 and took a look into it. I made it that when the wrong item ID `shoes_cavalry` which does not exist in the game is being looked up, it references the right one `boots_cavalry`. 

fixes #1